### PR TITLE
支持多个公众号accesstoken共存

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ type Article struct {
 更新日志
 -
 
+Release 20151002
+- 修改accesstoken存储规则,支持多个公众号并存
+
 Release 20140608
 
 - 创建/查询/删除自定义菜单

--- a/accesstoken.go
+++ b/accesstoken.go
@@ -19,7 +19,7 @@ type AccessToken struct {
 // get fresh access_token string
 func (this *AccessToken) Fresh() (string, error) {
 	if this.TmpName == "" {
-		this.TmpName = "accesstoken.tmp"
+		this.TmpName = this.AppId + "-accesstoken.tmp"
 	}
 	if this.LckName == "" {
 		this.LckName = this.TmpName + ".lck"


### PR DESCRIPTION
将公众号accesstoken存储的文件名由accesstoken.tmp改为 appId-accesstoken.tmp的方式,以支持同时存储多个token不会被覆盖.另增加了群发功能,希望原作者帮忙测试下